### PR TITLE
Change default excluded patterns

### DIFF
--- a/src/app/configs/constants.config.ts
+++ b/src/app/configs/constants.config.ts
@@ -86,13 +86,11 @@ export const EXCLUDE_PATTERNS: string[] = [
   '**/out/**',
   '**/build/**',
   '**/coverage/**',
-  '**/.*/**',
   '**/*.spec.*',
   '**/*.test.*',
   '**/*.e2e.*',
   '**/*.d.ts',
   '**/tsconfig.*',
-  '**/index.*',
 ];
 
 /**


### PR DESCRIPTION
Hi, I was trying to use your extension because I randomly found it in the store and saw it didn't work if I didn't override the default "ignoreFilePathPatternOnExport" setting.

I think my file structure is pretty common for a react project:

```
📁components
└── 📁scheduler
    └── 📁SchedulerBody
        └── index.tsx
        └── styles.scss
    └── 📁SchedulerHeader
        └── index.tsx
        └── styles.scss
    └── index.ts #file generated by extension with all the exports from 📁scheduler directory
```

And while looking at the default EXCLUDE_PATTERNS constant I was wondering why you put such generic templates (check changes) considering that the extension should work (I guess) for a folder containing nested directories that contain exports and not just at the root dir level.