### PR TITLE
Fix the `defaultLanguage` setting, so it is now applied properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the `defaultLanguage` setting, so it is now applied properly.
+
 ## [1.4.1] - 2024-05-14
 
 ### Fixed
@@ -51,9 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add basic functionality for generating barrel files.
 - Add support for TypeScript and JavaScript projects.
 
-[Unreleased]: https://github.com/ManuelGil/vscode-nextjs-generator/compare/v1.4.0...HEAD
-[1.4.0]: https://github.com/ManuelGil/vscode-nextjs-generator/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/ManuelGil/vscode-nextjs-generator/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/ManuelGil/vscode-nextjs-generator/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/ManuelGil/vscode-nextjs-generator/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/ManuelGil/vscode-nextjs-generator/releases/tag/v1.0.0
+[Unreleased]: https://github.com/ManuelGil/vscode-auto-barrel/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/ManuelGil/vscode-auto-barrel/compare/v1.4.0...v1.4.1
+[1.4.0]: https://github.com/ManuelGil/vscode-auto-barrel/compare/v1.3.0...v1.4.0
+[1.3.0]: https://github.com/ManuelGil/vscode-auto-barrel/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/ManuelGil/vscode-auto-barrel/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/ManuelGil/vscode-auto-barrel/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/ManuelGil/vscode-auto-barrel/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 			"properties": {
 				"autoBarrel.language.defaultLanguage": {
 					"type": "string",
-					"default": "typescript",
+					"default": "TypeScript",
 					"enum": [
 						"TypeScript",
 						"JavaScript"

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -4,7 +4,7 @@
 	"properties": {
 		"autoBarrel.language.defaultLanguage": {
 			"type": "string",
-			"default": "typescript",
+			"default": "TypeScript",
 			"enum": ["TypeScript", "JavaScript"],
 			"enumDescriptions": [
 				"Create a TypeScript barrel",

--- a/src/app/configs/constants.config.ts
+++ b/src/app/configs/constants.config.ts
@@ -44,7 +44,7 @@ export const EXTENSION_DISPLAY_NAME: string = 'Auto Barrel';
  *
  * @returns {string} - The default language
  */
-export const DEFAULT_LANGUAGE: string = 'typescript';
+export const DEFAULT_LANGUAGE: string = 'TypeScript';
 
 /**
  * RECURSIVE_BARRELLING: The flag to recursively barrel.

--- a/src/app/controllers/files.controller.ts
+++ b/src/app/controllers/files.controller.ts
@@ -70,7 +70,9 @@ export class FilesController {
 
     const content = await this.getContent(folderPath);
 
-    const ext = this.config.defaultLanguage === 'typescript' ? 'ts' : 'js';
+    const ext =
+      this.config.defaultLanguage.toLowerCase() === 'typescript' ? 'ts' : 'js';
+
     const filename = `index.${ext}`;
 
     if (content) {
@@ -99,7 +101,9 @@ export class FilesController {
       return;
     }
 
-    const ext = this.config.defaultLanguage === 'typescript' ? 'ts' : 'js';
+    const ext =
+      this.config.defaultLanguage.toLowerCase() === 'typescript' ? 'ts' : 'js';
+
     const filename = join(targetFile, `index.${ext}`);
 
     if (!existsSync(filename)) {


### PR DESCRIPTION
Hello, Manuel!
Thank you for the great extension!

### Description

This PR fixes the `defaultLanguage` setting, so it is now applied properly.
It also contains a small fix for the changelog links.

I was unsure what style you wanted to use for naming the values for this setting, but since you use them in PascalCase in the schema, I decided to keep them that way across the board and just use `toLowerCase()` when checking the value. This way, it shouldn't cause any problems for existing user configurations (e.g. those who have been using lowercase value despite the schema warning).